### PR TITLE
Add a close method to streaming connection instance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ const audioResponse = await speech.synthesize('Hello World.', firstVoiceId, { fo
 console.log(audioResponse);
 ```
 
-See the simple [demo apps](./demo/node/README.md) under `./demo/node` for more examples.
+See the simple [demo apps](https://github.com/lmnt-com/lmnt-node/tree/master/demo/node) for more examples.
 ## Release History
 
 0.0.1 / Sep 6, 2023

--- a/demo/node/stream.js
+++ b/demo/node/stream.js
@@ -60,6 +60,8 @@ const readTask = async () => {
     process.stdout.write(` ** LMNT -- ${audioBytes} bytes ** `);
     audioFile.write(message);
   }
+
+  speechConnection.close();
 };
 
 await Promise.all([writeTask(), readTask()]);

--- a/speech.js
+++ b/speech.js
@@ -66,6 +66,11 @@ class StreamingSynthesisConnection {
     this._sendMessage({"text": text});
   }
 
+  close() {
+    this._socket.close();
+    this._socket = null;
+  }
+
   finish() {
     this._sendMessage(MESSAGE_EOF);
   }
@@ -77,7 +82,7 @@ class StreamingSynthesisConnection {
   }
 
   _flushMessages() {
-    if (this._socket.readyState === WebSocket.OPEN) {
+    if (this._socket?.readyState === WebSocket.OPEN) {
       while (this._outMessages.length) {
         const message = this._outMessages.shift();
         logDebug(`Sending message:`, message);


### PR DESCRIPTION
I left this out of the first pass for the reason mentioned in the fuller commit comment, but on reflection felt like we should add it. Thoughts?

>    Caller use is effectively optional since eventually the connection
>    (and its accompanying socket) should be GC'd once no longer
>    referenced, but it seems proper to give developers a way to explicitly
>    free things if they have a reason to manage things more directly.