### PR TITLE
Ignore package lock files when publishing to npmjs module repo.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+npm.lock
+yarn.lock


### PR DESCRIPTION
Though we likely want them checked into our own repo during development where we want stable versions, the spirit of npmjs.org is to specify intended dependencies semantically in package.json.

Background -- I looked into the above a bit and this is my distilled conclusion. However, I have only myself published a limited number of modules to npmjs.org, so you could steer me differently.

I found when I published initially that `npm pack` (used by `publish`) filters `yarn.lock` files already. However, it missed the additional one we have under `demo/node` (which, you could argue, is different from the module itself and should perhaps actually be published, but we like to cross one bridge at a time and only go as far as Terabithia).