### PR TITLE
Queue up an end to streaming async iterator when socket is closed.

### DIFF
--- a/demo/node/stream.js
+++ b/demo/node/stream.js
@@ -65,3 +65,4 @@ const readTask = async () => {
 };
 
 await Promise.all([writeTask(), readTask()]);
+audioFile.close();

--- a/speech.d.ts
+++ b/speech.d.ts
@@ -40,6 +40,11 @@ declare module 'lmnt-node' {
     appendText(text: string): void;
 
     /**
+     * Releases resources associated with this instance.
+     */
+    close(): void;
+
+    /**
      * Call this when you've written all the text you're expecting to submit. It will
      * flush any remaining data to the server to ensure you receive any additional
      * synthesized speech audio via the async iterator.


### PR DESCRIPTION
Fixes demo issues where iterator would always stay in a pending possibly-there's-more-data state.

Also add a Typescript definition for the `Speech.close` method.