### PR TITLE
add language param to streaming synthesis

### DIFF
--- a/src/cjs/speech.js
+++ b/src/cjs/speech.js
@@ -102,6 +102,7 @@ class StreamingSynthesisConnection {
       'X-API-Key': apiKey,
       'voice': voice,
       'format': options.format || undefined,
+      'language': options.language || undefined,
       'sample_rate': options.sample_rate || undefined,
       'send_extras': options.return_extras || undefined,
       'speed': options.speed || undefined,

--- a/src/esm/speech.js
+++ b/src/esm/speech.js
@@ -103,6 +103,7 @@ class StreamingSynthesisConnection {
       'X-API-Key': apiKey,
       'voice': voice,
       'format': options.format || undefined,
+      'language': options.language || undefined,
       'sample_rate': options.sample_rate || undefined,
       'send_extras': options.return_extras || undefined,
       'speed': options.speed || undefined,

--- a/types.d.ts
+++ b/types.d.ts
@@ -29,32 +29,32 @@ declare module 'lmnt-node' {
    * and defaults.
    */
   export interface SynthesizeOptions {
-    /** An optional seed for random number generation. */
-    seed?: number;
-
     /** The desired output audio format. */
     format?: string;
-
-    /** The desired output audio sample rate. */
-    sample_rate?: 8000 | 16000 | 24000;
-
-    /** The desired speed of the synthesized speech. */
-    speed?: number;
-
-    /** The desired target length of the output speech in seconds. */
-    length?: number;
-
-    /** If `True`, the response will include word durations detail. */
-    return_durations?: boolean;
-
-    /** If `True`, the response will include the seed used for synthesis. */
-    return_seed?: boolean;
 
     /** 
      * The desired language of the synthesized speech. Two letter ISO 639-1
      * code. Defaults to `en`.
      */
     language?: string;
+
+    /** The desired target length of the output speech in seconds. */
+    length?: number;
+
+    /** The desired output audio sample rate. */
+    sample_rate?: 8000 | 16000 | 24000;
+
+    /** An optional seed for random number generation. */
+    seed?: number;
+
+    /** The desired speed of the synthesized speech. */
+    speed?: number;
+
+    /** If `True`, the response will include word durations detail. */
+    return_durations?: boolean;
+
+    /** If `True`, the response will include the seed used for synthesis. */
+    return_seed?: boolean;
   }
 
   /**
@@ -63,20 +63,26 @@ declare module 'lmnt-node' {
    * and defaults.
    */
   export interface StreamingSynthesisOptions {
+    /** The amount of variation in speech (e.g. pitch). */
+    expressive?: number;
+
     /** The desired output audio format. */
     format?: 'mp3' | 'raw' | 'ulaw';
 
-    /** The desired output audio sample rate. */
-    sample_rate?: 8000 | 16000 | 24000;
+    /** 
+     * The desired language of the synthesized speech. Two letter ISO 639-1
+     * code. Defaults to `en`.
+     */
+    language?: string;
 
     /** Whether to return extra data (durations data and warnings) with each audio chunk. */
     return_extras?: boolean;
 
+    /** The desired output audio sample rate. */
+    sample_rate?: 8000 | 16000 | 24000;
+
     /** The desired speed of the synthesized speech. */
     speed?: number;
-
-    /** The amount of variation in speech (e.g. pitch). */
-    expressive?: number;
   }
 
   export interface FetchVoicesOptions {


### PR DESCRIPTION
While regular synthesis got language params in #36, streaming synthesis also needs to accept a language value. Updates the first message sent by the streaming connection to include the language if specified by the caller. Also alpha-sorts the synthesis options.