### PR TITLE
docs: rebrand to LMNT TypeScript SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# LMNT Node SDK
+# LMNT TypeScript SDK
 
-[![NPM version](https://img.shields.io/npm/v/lmnt-node.svg)](https://npmjs.org/package/lmnt-node) ![npm bundle size](https://img.shields.io/bundlephobia/minzip/lmnt-node)
+[![NPM version](https://img.shields.io/npm/v/lmnt-node.svg)](https://npmjs.org/package/lmnt-node)
 
-The LMNT Node SDK provides convenient access to the LMNT API from server-side TypeScript applications.
+The LMNT TypeScript SDK provides convenient access to the LMNT API from server-side TypeScript applications.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
Rebrand the README from "LMNT Node SDK" to "LMNT TypeScript SDK" — the
package targets server-side TypeScript and the new framing matches the
docs site's terminology (docs.lmnt.com/api/sdks/typescript).

## Changed surface
- README title, intro sentence, and badge row updated
- No code, types, or package-name changes

## Test plan
- [ ] CI green