### PR TITLE
ci: run tests on Node 20, 22, and 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,16 +70,20 @@ jobs:
         run: ./scripts/utils/upload-artifact.sh
   test:
     timeout-minutes: 10
-    name: test
+    name: test (node-${{ matrix.node-version }})
     runs-on: ${{ github.repository == 'stainless-sdks/lmnt-com-node' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['20', '22', '24']
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node-version }}
 
       - name: Bootstrap
         run: ./scripts/bootstrap


### PR DESCRIPTION
## Summary
- Convert the `test` job into a matrix over Node 20, 22, and 24 with `fail-fast: false`.
- Keeps `lint` and `build` on Node 20 — those are runtime-independent.
- The README already declares Node 20 LTS as the floor, so the matrix matches the support claim. Bun and Deno coverage are deferred to a follow-up.

## Test plan
- [ ] All three matrix legs (`test (node-20)`, `test (node-22)`, `test (node-24)`) go green on this PR.
- [ ] `lint` and `build` jobs pass with no regression in duration.