### PR TITLE
chore: regenerate sdk

### DIFF
--- a/_carbonsteel.json
+++ b/_carbonsteel.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "generated_at": "2026-05-19T21:02:15Z",
+  "generated_at": "2026-05-21T00:34:15Z",
   "spec_sha": "4c822a78c44f68ac:cc7f4554e955f4fe",
   "files": [
     "api.md",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,3 @@
-// Vendored runtime. See carbonsteel README for provenance.
-
 import Lmnt from 'lmnt-node';
 import { APIUserAbortError } from 'lmnt-node';
 import { Headers } from 'lmnt-node/core';

--- a/tests/stringifyQuery.test.ts
+++ b/tests/stringifyQuery.test.ts
@@ -1,5 +1,3 @@
-// Vendored runtime. See carbonsteel README for provenance.
-
 import { Lmnt } from 'lmnt-node';
 
 const { stringifyQuery } = Lmnt.prototype as any;


### PR DESCRIPTION
## Summary
Pure regeneration — no API surface change. Removes a leftover provenance
comment (and its blank line) from the top of two test files so they start
straight at their imports, consistent with the other test files.

## Changed surface
- No public API change — test files only.