### PR TITLE
feat(api): target API version 1.2

### DIFF
--- a/_carbonsteel.json
+++ b/_carbonsteel.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.1",
-  "generated_at": "2026-05-21T00:34:15Z",
-  "spec_sha": "4c822a78c44f68ac:cc7f4554e955f4fe",
+  "version": "1.2",
+  "generated_at": "2026-06-03T23:58:38Z",
+  "spec_sha": "3ac0d7427265f74f:f147e87623a53da9",
   "files": [
     "api.md",
     "src/_shims/MultipartBody.ts",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const VERSION = '2.12.2'; // x-release-please-version
-export const LMNT_API_VERSION = '1.1';
+export const LMNT_API_VERSION = '1.2';

--- a/tests/api-resources/sessions.test.ts
+++ b/tests/api-resources/sessions.test.ts
@@ -57,7 +57,7 @@ describe('resource sessions', () => {
     expect(fake.sent.length).toBe(1);
     const init = JSON.parse(fake.sent[0]);
     expect(init['X-API-Key']).toBe('test-api-key');
-    expect(init['lmnt-version']).toBe('1.1');
+    expect(init['lmnt-version']).toBe('1.2');
     expect(init.voice).toBe('voice-id');
     session.close();
   });


### PR DESCRIPTION
## Summary
The client now targets API version 1.2 (`lmnt-version: 1.2`). In speech sessions, word timestamps now have cumulative `start` times that are aligned to the audio you receive and reset to `0.0` after a `flush` or `reset`, so you no longer need to offset them yourself.

## Changed surface
- `SpeechSessionTimestamps.timestamps`: updated docs — start times are cumulative and reset after a `flush`/`reset`.
- Outgoing requests now send `lmnt-version: 1.2`.